### PR TITLE
Add all remaining Thaumcraft mixins from Universal Tweaks

### DIFF
--- a/src/main/java/thecodex6824/thaumcraftfix/core/ThaumcraftFixCore.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/core/ThaumcraftFixCore.java
@@ -134,9 +134,9 @@ public class ThaumcraftFixCore implements IFMLLoadingPlugin {
     }
 
     public static List<String> getLateMixinConfigs() {
-	return ImmutableList.of("mixin/aura.json", "mixin/block.json", "mixin/event.json",
-		"mixin/focus.json", "mixin/item.json", "mixin/network.json", "mixin/render.json",
-		"mixin/tile.json", "mixin/util.json");
+	return ImmutableList.of("mixin/aura.json", "mixin/block.json", "mixin/entity.json",
+		"mixin/event.json", "mixin/focus.json", "mixin/item.json", "mixin/network.json",
+		"mixin/render.json", "mixin/tile.json", "mixin/util.json");
     }
 
 }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/entity/EntityFocusMineMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/entity/EntityFocusMineMixin.java
@@ -1,0 +1,80 @@
+/**
+ *  Thaumcraft Fix
+ *  Copyright (c) 2024 TheCodex6824.
+ *
+ *  This file is part of Thaumcraft Fix.
+ *
+ *  Thaumcraft Fix is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Thaumcraft Fix is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Thaumcraft Fix.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package thecodex6824.thaumcraftfix.mixin.entity;
+
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import thaumcraft.api.casters.FocusEffect;
+import thaumcraft.common.entities.projectile.EntityFocusMine;
+import thaumcraft.common.lib.SoundsTC;
+
+// Normally focus mines are a little confusing without some sounds to indicate on what they're doing.
+@Mixin(EntityFocusMine.class)
+public abstract class EntityFocusMineMixin extends EntityThrowable {
+
+    @Shadow(remap = false)
+    public int counter;
+
+    @Shadow(remap = false)
+    FocusEffect[] effects;
+
+    public EntityFocusMineMixin(World world) {
+        super(world);
+    }
+
+    @Inject(method = "onUpdate", at = @At(value = "HEAD"))
+    public void onUpdateSounds(CallbackInfo ci) {
+        try {
+            // Plays when the focus mine despawns.
+            if (this.ticksExisted > 1200 || (!this.world.isRemote && this.getThrower() == null)) {
+                this.playSound(SoundsTC.craftfail, 1.0F, 1.0F + (rand.nextFloat() * 0.5F));
+            }
+
+            // Plays when the focus mine is ready and armed.
+            if (this.isEntityAlive()) {
+                if (this.counter == 1 && this.effects == null) {
+                    this.playSound(SoundsTC.hhoff, 1.0F, 1.0F + (rand.nextFloat() * 0.5F));
+                }
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Inject(method = "onImpact", at = @At(value = "HEAD"))
+    protected void onImpactSound(final RayTraceResult mop, CallbackInfo ci) {
+        try {
+            // Plays when the focus mine is setting itself up.
+            if (this.counter > 0) {
+                this.playSound(SoundsTC.ticks, 1.0F, 1.0F + (rand.nextFloat() * 0.5F));
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+}

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectBreakMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectBreakMixin.java
@@ -21,6 +21,7 @@
 package thecodex6824.thaumcraftfix.mixin.focus;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.RayTraceResult;
 
@@ -29,33 +30,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
+import thaumcraft.common.items.casters.foci.FocusEffectBreak;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
+@Mixin(FocusEffectBreak.class)
+public abstract class FocusEffectBreakMixin extends FocusEffect {
 
     @Override
     public void onCast(final Entity caster) {
         try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
+            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.rumble, SoundCategory.PLAYERS, 0.6F, 3.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void breakFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.ENTITY_FIREWORK_TWINKLE, SoundCategory.PLAYERS, 0.4F, 1.5F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectEarthMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectEarthMixin.java
@@ -21,6 +21,7 @@
 package thecodex6824.thaumcraftfix.mixin.focus;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.RayTraceResult;
 
@@ -29,33 +30,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
+import thaumcraft.common.items.casters.foci.FocusEffectEarth;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
+@Mixin(FocusEffectEarth.class)
+public abstract class FocusEffectEarthMixin extends FocusEffect {
 
     @Override
     public void onCast(final Entity caster) {
         try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
+            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.grind, SoundCategory.PLAYERS, 1.0F, 0.7F + (float) (caster.world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void earthFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.ENTITY_FIREWORK_LARGE_BLAST, SoundCategory.PLAYERS, 0.55F, 0.7F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectFireMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectFireMixin.java
@@ -20,7 +20,7 @@
 
 package thecodex6824.thaumcraftfix.mixin.focus;
 
-import net.minecraft.entity.Entity;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.RayTraceResult;
 
@@ -29,33 +29,17 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
-import thaumcraft.common.lib.SoundsTC;
+import thaumcraft.common.items.casters.foci.FocusEffectFire;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
-
-    @Override
-    public void onCast(final Entity caster) {
-        try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
-        } catch (Exception ignored) {
-        }
-    }
+@Mixin(FocusEffectFire.class)
+public abstract class FocusEffectFireMixin extends FocusEffect {
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void fireFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.ENTITY_FIREWORK_BLAST, SoundCategory.PLAYERS, 0.525F, 0.3F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectFluxMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectFluxMixin.java
@@ -20,7 +20,7 @@
 
 package thecodex6824.thaumcraftfix.mixin.focus;
 
-import net.minecraft.entity.Entity;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.RayTraceResult;
 
@@ -29,33 +29,17 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
-import thaumcraft.common.lib.SoundsTC;
+import thaumcraft.common.items.casters.foci.FocusEffectFlux;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
-
-    @Override
-    public void onCast(final Entity caster) {
-        try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
-        } catch (Exception ignored) {
-        }
-    }
+@Mixin(FocusEffectFlux.class)
+public abstract class FocusEffectFluxMixin extends FocusEffect {
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void fluxFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.BLOCK_CHORUS_FLOWER_DEATH, SoundCategory.PLAYERS, 1.5F, 2.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectFrostMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectFrostMixin.java
@@ -21,6 +21,7 @@
 package thecodex6824.thaumcraftfix.mixin.focus;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.RayTraceResult;
 
@@ -29,33 +30,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
+import thaumcraft.common.items.casters.foci.FocusEffectFrost;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
+@Mixin(FocusEffectFrost.class)
+public abstract class FocusEffectFrostMixin extends FocusEffect {
 
     @Override
     public void onCast(final Entity caster) {
         try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
+            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.ice, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void earthFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 0.55F, 0.86F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectHealMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectHealMixin.java
@@ -29,33 +29,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
+import thaumcraft.common.items.casters.foci.FocusEffectHeal;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
+@Mixin(FocusEffectHeal.class)
+public abstract class FocusEffectHealMixin extends FocusEffect {
 
     @Override
     public void onCast(final Entity caster) {
         try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
+            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.wand, SoundCategory.PLAYERS, 0.825F, 3.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void earthFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.wand, SoundCategory.PLAYERS, 0.525F, 0.7F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectHealMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectHealMixin.java
@@ -46,7 +46,7 @@ public abstract class FocusEffectHealMixin extends FocusEffect {
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void earthFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void healFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
             this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.wand, SoundCategory.PLAYERS, 0.525F, 0.7F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectRiftMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectRiftMixin.java
@@ -32,10 +32,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectFrost;
+import thaumcraft.common.items.casters.foci.FocusEffectRift;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectFrost.class)
+@Mixin(FocusEffectRift.class)
 public abstract class FocusEffectRiftMixin extends FocusEffect {
 
     @Override

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectRiftMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectRiftMixin.java
@@ -47,7 +47,7 @@ public abstract class FocusEffectRiftMixin extends FocusEffect {
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void earthFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void riftFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
             this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.ENTITY_ILLAGER_MIRROR_MOVE, SoundCategory.PLAYERS, 0.75F, 1.25F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectRiftMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusEffectRiftMixin.java
@@ -21,6 +21,7 @@
 package thecodex6824.thaumcraftfix.mixin.focus;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.RayTraceResult;
 
@@ -29,33 +30,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
-
 import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectExchange;
+import thaumcraft.common.items.casters.foci.FocusEffectFrost;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectExchange.class)
-public abstract class FocusEffectExchangeMixin extends FocusEffect {
-
-    @ModifyReturnValue(method = "getComplexity", at = @At("RETURN"), remap = false)
-    private int addComplexityForSilkTouch(int original) {
-        return original + (getSettingValue("silk") > 0 ? 4 : 0);
-    }
+@Mixin(FocusEffectFrost.class)
+public abstract class FocusEffectRiftMixin extends FocusEffect {
 
     @Override
     public void onCast(final Entity caster) {
         try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.hhoff, SoundCategory.PLAYERS, 0.8F, 0.45F + (float) (caster.world.rand.nextGaussian() * 0.05F));
+            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.craftstart, SoundCategory.PLAYERS, 0.65F, 1.4F + (float) (caster.world.rand.nextGaussian() * 0.1F));
         } catch (Exception ignored) {
         }
     }
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void exchangeFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void earthFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundsTC.hhon, SoundCategory.PLAYERS, 0.8F, 0.85F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.ENTITY_ILLAGER_MIRROR_MOVE, SoundCategory.PLAYERS, 0.75F, 1.25F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumBoltMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumBoltMixin.java
@@ -20,36 +20,25 @@
 
 package thecodex6824.thaumcraftfix.mixin.focus;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.RayTraceResult;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import thaumcraft.api.casters.FocusEffect;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectFrost;
+import thaumcraft.common.items.casters.foci.FocusMediumBolt;
+import thaumcraft.common.items.casters.foci.FocusMediumTouch;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectFrost.class)
-public abstract class FocusEffectFrostMixin extends FocusEffect {
-
-    @Override
-    public void onCast(final Entity caster) {
-        try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.ice, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
-        } catch (Exception ignored) {
-        }
-    }
+@Mixin(FocusMediumBolt.class)
+public abstract class FocusMediumBoltMixin extends FocusMediumTouch {
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void frostFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void boltFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 0.55F, 0.86F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundsTC.shock, SoundCategory.PLAYERS, 0.175F, 1.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumCloudMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumCloudMixin.java
@@ -20,36 +20,25 @@
 
 package thecodex6824.thaumcraftfix.mixin.focus;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.RayTraceResult;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import thaumcraft.api.casters.FocusEffect;
+import thaumcraft.api.casters.FocusMedium;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectFrost;
+import thaumcraft.common.items.casters.foci.FocusMediumCloud;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectFrost.class)
-public abstract class FocusEffectFrostMixin extends FocusEffect {
-
-    @Override
-    public void onCast(final Entity caster) {
-        try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.ice, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
-        } catch (Exception ignored) {
-        }
-    }
+@Mixin(FocusMediumCloud.class)
+public abstract class FocusMediumCloudMixin extends FocusMedium {
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void frostFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void cloudFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 0.55F, 0.86F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundsTC.egscreech, SoundCategory.PLAYERS, 0.25F, 1.25F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumMineMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumMineMixin.java
@@ -20,36 +20,25 @@
 
 package thecodex6824.thaumcraftfix.mixin.focus;
 
-import net.minecraft.entity.Entity;
-import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.RayTraceResult;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import thaumcraft.api.casters.FocusEffect;
+import thaumcraft.api.casters.FocusMedium;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectFrost;
+import thaumcraft.common.items.casters.foci.FocusMediumMine;
 import thaumcraft.common.lib.SoundsTC;
 
-@Mixin(FocusEffectFrost.class)
-public abstract class FocusEffectFrostMixin extends FocusEffect {
-
-    @Override
-    public void onCast(final Entity caster) {
-        try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.ice, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
-        } catch (Exception ignored) {
-        }
-    }
+@Mixin(FocusMediumMine.class)
+public abstract class FocusMediumMineMixin extends FocusMedium {
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void frostFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void mineFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 0.55F, 0.86F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundsTC.upgrade, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumSpellbatMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/focus/FocusMediumSpellbatMixin.java
@@ -20,36 +20,25 @@
 
 package thecodex6824.thaumcraftfix.mixin.focus;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.RayTraceResult;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import thaumcraft.api.casters.FocusEffect;
+import thaumcraft.api.casters.FocusMedium;
 import thaumcraft.api.casters.Trajectory;
-import thaumcraft.common.items.casters.foci.FocusEffectFrost;
-import thaumcraft.common.lib.SoundsTC;
+import thaumcraft.common.items.casters.foci.FocusMediumSpellBat;
 
-@Mixin(FocusEffectFrost.class)
-public abstract class FocusEffectFrostMixin extends FocusEffect {
-
-    @Override
-    public void onCast(final Entity caster) {
-        try {
-            caster.world.playSound(null, caster.getPosition().up(), SoundsTC.ice, SoundCategory.PLAYERS, 0.6F, 1.0F + (float) (caster.world.rand.nextGaussian() * 0.05F));
-        } catch (Exception ignored) {
-        }
-    }
+@Mixin(FocusMediumSpellBat.class)
+public abstract class FocusMediumSpellbatMixin extends FocusMedium {
 
     @Inject(method = "execute", at = @At(value = "RETURN"), remap = false)
-    public void frostFocusImpactSound(RayTraceResult target, Trajectory trajectory, float finalPower, int num, CallbackInfoReturnable<Boolean> cir) {
+    public void spellbatFocusSound(Trajectory trajectory, CallbackInfoReturnable<Boolean> cir) {
         try {
-            this.getPackage().world.playSound(null, target.hitVec.x, target.hitVec.y, target.hitVec.z, SoundEvents.BLOCK_GLASS_BREAK, SoundCategory.PLAYERS, 0.55F, 0.86F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
+            this.getPackage().world.playSound(null, this.getPackage().getCaster().getPosition().up(), SoundEvents.ENTITY_WITHER_SHOOT, SoundCategory.PLAYERS, 0.45F, 1.0F + (float) (this.getPackage().getCaster().world.rand.nextGaussian() * 0.05F));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/item/ItemThaumometerMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/item/ItemThaumometerMixin.java
@@ -1,0 +1,46 @@
+/**
+ *  Thaumcraft Fix
+ *  Copyright (c) 2024 TheCodex6824.
+ *
+ *  This file is part of Thaumcraft Fix.
+ *
+ *  Thaumcraft Fix is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Thaumcraft Fix is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Thaumcraft Fix.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package thecodex6824.thaumcraftfix.mixin.item;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import thaumcraft.common.items.tools.ItemThaumometer;
+
+@Mixin(ItemThaumometer.class)
+public class ItemThaumometerMixin {
+
+    // No more excessive bobbing when scanning
+    @Inject(method = "onItemRightClick", at = @At(value = "RETURN"), cancellable = true)
+    public void stabilizeThaumometer(World world, EntityPlayer p, EnumHand hand, CallbackInfoReturnable<ActionResult<ItemStack>> cir) {
+        cir.setReturnValue(new ActionResult<>(EnumActionResult.FAIL, p.getHeldItem(hand)));
+    }
+
+}

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/render/RenderEldritchCrabMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/render/RenderEldritchCrabMixin.java
@@ -1,0 +1,45 @@
+/**
+ *  Thaumcraft Fix
+ *  Copyright (c) 2024 TheCodex6824.
+ *
+ *  This file is part of Thaumcraft Fix.
+ *
+ *  Thaumcraft Fix is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Thaumcraft Fix is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Thaumcraft Fix.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package thecodex6824.thaumcraftfix.mixin.render;
+
+import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.entity.RenderLiving;
+import net.minecraft.client.renderer.entity.RenderManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import thaumcraft.client.renderers.entity.mob.RenderEldritchCrab;
+import thaumcraft.common.entities.monster.EntityEldritchCrab;
+
+@Mixin(RenderEldritchCrab.class)
+public abstract class RenderEldritchCrabMixin extends RenderLiving<EntityEldritchCrab> {
+
+    public RenderEldritchCrabMixin(RenderManager rendermanagerIn, ModelBase modelbaseIn, float shadowsizeIn) {
+        super(rendermanagerIn, modelbaseIn, shadowsizeIn);
+    }
+
+    // Makes eldritch crabs rotate all the way during death like spiders, this would make more sense visually.
+    @Override
+    public float getDeathMaxRotation(EntityEldritchCrab entity) {
+        return 180.0F;
+    }
+
+}

--- a/src/main/resources/mixin/entity.json
+++ b/src/main/resources/mixin/entity.json
@@ -1,0 +1,9 @@
+{
+  "package": "thecodex6824.thaumcraftfix.mixin.entity",
+  "refmap": "${refmap}",
+  "minVersion": "${mixinminversion}",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "EntityFocusMineMixin"
+  ]
+}

--- a/src/main/resources/mixin/focus.json
+++ b/src/main/resources/mixin/focus.json
@@ -4,6 +4,13 @@
   "minVersion": "${mixinminversion}",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "FocusEffectExchangeMixin"
+    "FocusEffectBreakMixin",
+    "FocusEffectEarthMixin",
+    "FocusEffectExchangeMixin",
+    "FocusEffectFireMixin",
+    "FocusEffectFluxMixin",
+    "FocusEffectFrostMixin",
+    "FocusEffectHealMixin",
+    "FocusEffectRiftMixin"
   ]
 }

--- a/src/main/resources/mixin/focus.json
+++ b/src/main/resources/mixin/focus.json
@@ -11,6 +11,10 @@
     "FocusEffectFluxMixin",
     "FocusEffectFrostMixin",
     "FocusEffectHealMixin",
-    "FocusEffectRiftMixin"
+    "FocusEffectRiftMixin",
+    "FocusMediumBoltMixin",
+    "FocusMediumCloudMixin",
+    "FocusMediumMineMixin",
+    "FocusMediumSpellbatMixin"
   ]
 }

--- a/src/main/resources/mixin/item.json
+++ b/src/main/resources/mixin/item.json
@@ -6,6 +6,7 @@
   "mixins": [
     "ItemElementalShovelMixin",
     "ItemGenericEssentiaContainerMixin",
+    "ItemThaumometerMixin",
     "ItemPrimordialPearlMixin"
   ]
 }

--- a/src/main/resources/mixin/render.json
+++ b/src/main/resources/mixin/render.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "client": [
     "ModelCustomArmorMixin",
-    "ModelRobeMixin"
+    "ModelRobeMixin",
+    "RenderEldritchCrabMixin"
   ]
 }


### PR DESCRIPTION
Adds all the remaining Thaumcraft mixins from Universal Tweaks, compatibility won't be an issue because they will be removed from Universal Tweaks as soon as they get integrated here. :)

Not sure if the code would need to be adjusted, but so far from testing I've had no issues. This should now cover most of #3.

- The Thaumometer will no longer bob constantly when scanning. Still works fine with mods that touch the same class like TC4 Research Port and New Crimson Revelations.
- Dying Eldritch Crabs will rotate all the way like spiders.
- Focus mines now make sounds to further indicate their status (despawning, activating, and setting up).
- Some focus mediums now have cast sounds to make them more special (bolt, cloud, mine, and spellbat).
- All focus effects without impact sounds like Air or Curse now have them.
- Most focus effects have overhauled sounds that are more fitting especially to Frost.