### PR TITLE
Simple Nullguard to prevent NPE in RenderEventHandler#clientWorldTick

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Thaumcraft Fix is licensed under the GNU Lesser Public License v3 (or later). So
   - Deregistered spellbat spawn egg to prevent a crash when using it
   - Fixed Flux pollution client crash with large pollution values
   - Fixed Magical Mirrors causing a crash when they link to an invalid dimension
+  - Fixed Invalid essentia source FX entries causing NPE
 
 - **Duping:**
   - Fixed duplication issue with brain jars

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/render/RenderEventHandlerMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/render/RenderEventHandlerMixin.java
@@ -1,0 +1,35 @@
+package thecodex6824.thaumcraftfix.mixin.render;
+
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.client.lib.events.RenderEventHandler;
+import thaumcraft.common.lib.events.EssentiaHandler;
+
+@SideOnly(Side.CLIENT)
+@Mixin(value = RenderEventHandler.class, remap = false)
+public abstract class RenderEventHandlerMixin {
+
+    /**
+     * @author kaduvill
+     * @reason Prevents a client crash when Thaumcraft's essentia particle queue contains
+     * stale/null EssentiaSourceFX entries or entries missing their start/end position.
+     */
+    @Inject(method = "clientWorldTick", at = @At("HEAD"))
+    private static void thaumcraftfix$removeInvalidEssentiaSourceFX(TickEvent.ClientTickEvent event, CallbackInfo ci) {
+        if (event.side == Side.SERVER || event.phase != TickEvent.Phase.START
+                || EssentiaHandler.sourceFX == null || EssentiaHandler.sourceFX.isEmpty()) {
+            return;
+        }
+
+        EssentiaHandler.sourceFX.entrySet().removeIf(entry -> {
+            EssentiaHandler.EssentiaSourceFX fx = entry.getValue();
+            return fx == null || fx.start == null || fx.end == null;
+        });
+    }
+
+}

--- a/src/main/resources/mixin/render.json
+++ b/src/main/resources/mixin/render.json
@@ -10,6 +10,7 @@
     "ModelRobeMixin",
     "ProxyEntitiesMixin",
     "RenderEldritchCrabMixin",
-    "RenderFluxRiftMixin"
+    "RenderFluxRiftMixin",
+    "RenderEventHandlerMixin"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a client crash in `RenderEventHandler#clientWorldTick` when Thaumcraft's essentia particle queue contains a stale or malformed `EssentiaSourceFX` entry. Thaumcraft assumes every `sourceFX` entry is non-null and has valid `start`/`end` positions, so this PR removes invalid entries before the queue is processed.

## Start of Crash log:

```text
java.lang.NullPointerException: Cannot read field "start" because "fx" is null
    at thaumcraft.client.lib.events.RenderEventHandler.clientWorldTick(RenderEventHandler.java:251)
```

## Notes

- This only drops malformed visual essentia FX entries. Valid FX entries are untouched, and the original Thaumcraft logic continues normally.
- This crash is rare enough, that its hard to trigger:
- TIAB/Torcherino + Essentia flowing through the Air was involved in all known cases.
