### PR TITLE
Fix Aspect Tooltip Rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Thaumcraft Fix is licensed under the GNU Lesser Public License v3 (or later). So
   - Fixed Thaumcraft OBJ models having a lighting multiplier that made them darker
   - Fixed Void Thaumaturge Robes displaying twice the amount of armor on the hud
   - Fixed Wisps having really small burst particles on death
+  - Fixed some mods making the aspect tooltip to render in an incorrect position
   - Stopped screen shake and damage sound if fall damage is reduced to 0 from gear
 
 ---

--- a/src/main/java/thecodex6824/thaumcraftfix/mixin/client/RenderEventHandlerMixin.java
+++ b/src/main/java/thecodex6824/thaumcraftfix/mixin/client/RenderEventHandlerMixin.java
@@ -1,0 +1,26 @@
+package thecodex6824.thaumcraftfix.mixin.client;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import thaumcraft.client.lib.events.RenderEventHandler;
+
+@SideOnly(Side.CLIENT)
+@Mixin(value = RenderEventHandler.class, remap = false)
+public class RenderEventHandlerMixin {
+    /**
+     * @author WaitingIdly
+     * @reason When finding the relevant line to place the aspect icons,
+     * check that this line doesn't have any other text to avoid mis-identifying and
+     * attempting to render the aspect icons over text.
+     */
+    @WrapOperation(method = "tooltipEvent(Lnet/minecraftforge/client/event/RenderTooltipEvent$PostBackground;)V", at = @At(value = "INVOKE", target = "Ljava/lang/String;contains(Ljava/lang/CharSequence;)Z"))
+    private static boolean ensureCorrectLine(String instance, CharSequence charSequence, Operation<Boolean> original) {
+        return StringUtils.isBlank(StringUtils.remove(instance, TextFormatting.GRAY.toString())) && original.call(instance, charSequence);
+    }
+}

--- a/src/main/resources/mixin/client.json
+++ b/src/main/resources/mixin/client.json
@@ -10,6 +10,7 @@
     "GuiTurretAdvancedMixin",
     "GuiTurretBasicMixin",
     "HudHandlerMixin",
-    "KeyHandlerMixin"
+    "KeyHandlerMixin",
+    "RenderEventHandlerMixin"
   ]
 }


### PR DESCRIPTION
changes in this PR:
- add a mixin to thaumcraft's `RenderEventHandler.tooltipEvent(RenderTooltipEvent.PostBackground)` that changes the logic of how it finds the correct line. now, instead of matching any line with 4 spaces (`    `), it also checks if the line, aside from the starting `TextFormatting.GRAY` format symbol, is blank.

this fixes an issue where the having a mod such as Actually Additions (`curse.maven:actually-additions-228404:3117927`) or Actually Advanced Info (`curse.maven:aainfo-573154:3627065`) would cause the tooltip to be rendered incorrectly - for these mods, the additional tooltips only occur when advanced info `f3+h` is enabled, but any mod that adds a tooltip that adds a new line to the tooltip that contains 4 spaces could cause the same issue.

<img width="336" height="310" alt="image" src="https://github.com/user-attachments/assets/82b3118f-7f7f-40fe-a98e-f9a4240a4031" />
<img width="336" height="310" alt="image" src="https://github.com/user-attachments/assets/6acb28d8-c419-466e-ae61-7f29d43da0e7" />